### PR TITLE
Fix: Ensure homepage images are color, content monochrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
         }
         
         /* Ensure these specific images are never grayscale under any circumstances */
+        /*
         .force-color,
         .force-color *,
         .tab-image.force-color,
@@ -82,13 +83,16 @@
         }
         
         /* Create a separate stacking context for the entire services section */
+        /*
         #print-services {
             isolation: isolate !important;
             position: relative !important;
             z-index: 200 !important;
         }
+        */
     </style>
     <!-- Script to force colored images -->
+    <!--
     <script>
         // This script runs as soon as possible to ensure images are displayed in color
         document.addEventListener('DOMContentLoaded', function() {
@@ -127,6 +131,7 @@
             }
         });
     </script>
+    -->
 </head>
 <body>
     <header>

--- a/monochrome.css
+++ b/monochrome.css
@@ -25,6 +25,7 @@ footer {
 }
 
 /* DIRECT EXEMPTION for force-color elements - these must NEVER be grayscale */
+/*
 .force-color,
 .force-color *,
 .tab-image.force-color,
@@ -49,8 +50,10 @@ main > section.print-services .tab-content .tab-image.force-color {
     position: relative !important;
     z-index: 9999 !important;
 }
+*/
 
 /* EXEMPTION for tab images - these need to stay in color */
+/*
 .tab-image,
 .tab-image *,
 .color-wrapper,
@@ -64,6 +67,7 @@ main > section.print-services .tab-content .tab-image.force-color {
     z-index: 100 !important;
     position: relative !important;
 }
+*/
 
 /* Ensure body itself does not have the filter, to avoid double-filtering or unexpected inheritance */
 body {


### PR DESCRIPTION
- I modified CSS to ensure all `<img>` tags on the homepage display in full color by making `color-images.css` the primary source of truth for image colorization.
- I commented out redundant inline CSS and JavaScript in `index.html` that also attempted to force image colors.
- I commented out redundant color exemption rules in `monochrome.css`.
- The overall effect is that `monochrome.css` continues to provide a grayscale theme for non-image elements in main page sections, while `color-images.css` ensures `<img>` elements within these sections 'escape' the grayscale filter and display in color using `isolation: isolate` and `filter: grayscale(0%)`.
- This addresses the issue of images appearing grayscale while respecting the requirement for other content to be monochrome.